### PR TITLE
build(bump): dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,30 +8,30 @@
 			"name": "compare-pdf",
 			"version": "3.0.0",
 			"dependencies": {
-				"@napi-rs/canvas": "^0.1.94",
+				"@napi-rs/canvas": "^0.1.96",
 				"gm": "^1.25.1",
-				"pdfjs-dist": "^5.4.624",
+				"pdfjs-dist": "^5.5.207",
 				"pixelmatch": "^7.1.0",
 				"pngjs": "^7.0.0"
 			},
 			"devDependencies": {
-				"@commitlint/cli": "^20.4.2",
-				"@commitlint/config-conventional": "^20.4.2",
-				"@commitlint/format": "^20.4.0",
+				"@commitlint/cli": "^20.4.3",
+				"@commitlint/config-conventional": "^20.4.3",
+				"@commitlint/format": "^20.4.3",
 				"@eslint/js": "^10.0.1",
 				"@prettier/plugin-xml": "^3.4.2",
 				"@stylistic/eslint-plugin": "^5.9.0",
 				"@types/mocha": "^10.0.10",
 				"chai": "^6.2.2",
 				"chai-files": "^1.4.0",
-				"eslint": "^10.0.1",
+				"eslint": "^10.0.2",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-markdown": "^5.1.0",
 				"eslint-plugin-prettier": "^5.5.5",
-				"globals": "^17.3.0",
+				"globals": "^17.4.0",
 				"husky": "^9.1.7",
-				"lint-staged": "^16.2.7",
-				"mocha": "^11.7.5",
+				"lint-staged": "^16.3.2",
+				"mocha": "12.0.0-beta-10",
 				"prettier": "^3.8.1",
 				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.56.1"
@@ -66,17 +66,17 @@
 			}
 		},
 		"node_modules/@commitlint/cli": {
-			"version": "20.4.2",
-			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.2.tgz",
-			"integrity": "sha512-YjYSX2yj/WsVoxh9mNiymfFS2ADbg2EK4+1WAsMuckwKMCqJ5PDG0CJU/8GvmHWcv4VRB2V02KqSiecRksWqZQ==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.3.tgz",
+			"integrity": "sha512-Z37EMoDT7+Upg500vlr/vZrgRsb6Xc5JAA3Tv7BYbobnN/ZpqUeZnSLggBg2+1O+NptRDtyujr2DD1CPV2qwhA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/format": "^20.4.0",
-				"@commitlint/lint": "^20.4.2",
-				"@commitlint/load": "^20.4.0",
-				"@commitlint/read": "^20.4.0",
-				"@commitlint/types": "^20.4.0",
+				"@commitlint/format": "^20.4.3",
+				"@commitlint/lint": "^20.4.3",
+				"@commitlint/load": "^20.4.3",
+				"@commitlint/read": "^20.4.3",
+				"@commitlint/types": "^20.4.3",
 				"tinyexec": "^1.0.0",
 				"yargs": "^17.0.0"
 			},
@@ -88,27 +88,27 @@
 			}
 		},
 		"node_modules/@commitlint/config-conventional": {
-			"version": "20.4.2",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.2.tgz",
-			"integrity": "sha512-rwkTF55q7Q+6dpSKUmJoScV0f3EpDlWKw2UPzklkLS4o5krMN1tPWAVOgHRtyUTMneIapLeQwaCjn44Td6OzBQ==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.3.tgz",
+			"integrity": "sha512-9RtLySbYQAs8yEqWEqhSZo9nYhbm57jx7qHXtgRmv/nmeQIjjMcwf6Dl+y5UZcGWgWx435TAYBURONaJIuCjWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.0",
-				"conventional-changelog-conventionalcommits": "^9.1.0"
+				"@commitlint/types": "^20.4.3",
+				"conventional-changelog-conventionalcommits": "^9.2.0"
 			},
 			"engines": {
 				"node": ">=v18"
 			}
 		},
 		"node_modules/@commitlint/config-validator": {
-			"version": "20.4.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.0.tgz",
-			"integrity": "sha512-zShmKTF+sqyNOfAE0vKcqnpvVpG0YX8F9G/ZIQHI2CoKyK+PSdladXMSns400aZ5/QZs+0fN75B//3Q5CHw++w==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.3.tgz",
+			"integrity": "sha512-jCZpZFkcSL3ZEdL5zgUzFRdytv3xPo8iukTe9VA+QGus/BGhpp1xXSVu2B006GLLb2gYUAEGEqv64kTlpZNgmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.0",
+				"@commitlint/types": "^20.4.3",
 				"ajv": "^8.11.0"
 			},
 			"engines": {
@@ -116,13 +116,13 @@
 			}
 		},
 		"node_modules/@commitlint/ensure": {
-			"version": "20.4.1",
-			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.1.tgz",
-			"integrity": "sha512-WLQqaFx1pBooiVvBrA1YfJNFqZF8wS/YGOtr5RzApDbV9tQ52qT5VkTsY65hFTnXhW8PcDfZLaknfJTmPejmlw==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.3.tgz",
+			"integrity": "sha512-WcXGKBNn0wBKpX8VlXgxqedyrLxedIlLBCMvdamLnJFEbUGJ9JZmBVx4vhLV3ZyA8uONGOb+CzW0Y9HDbQ+ONQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.0",
+				"@commitlint/types": "^20.4.3",
 				"lodash.camelcase": "^4.3.0",
 				"lodash.kebabcase": "^4.1.1",
 				"lodash.snakecase": "^4.1.1",
@@ -144,13 +144,13 @@
 			}
 		},
 		"node_modules/@commitlint/format": {
-			"version": "20.4.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.0.tgz",
-			"integrity": "sha512-i3ki3WR0rgolFVX6r64poBHXM1t8qlFel1G1eCBvVgntE3fCJitmzSvH5JD/KVJN/snz6TfaX2CLdON7+s4WVQ==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.3.tgz",
+			"integrity": "sha512-UDJVErjLbNghop6j111rsHJYGw6MjCKAi95K0GT2yf4eeiDHy3JDRLWYWEjIaFgO+r+dQSkuqgJ1CdMTtrvHsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.0",
+				"@commitlint/types": "^20.4.3",
 				"picocolors": "^1.1.1"
 			},
 			"engines": {
@@ -158,13 +158,13 @@
 			}
 		},
 		"node_modules/@commitlint/is-ignored": {
-			"version": "20.4.1",
-			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.1.tgz",
-			"integrity": "sha512-In5EO4JR1lNsAv1oOBBO24V9ND1IqdAJDKZiEpdfjDl2HMasAcT7oA+5BKONv1pRoLG380DGPE2W2RIcUwdgLA==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.3.tgz",
+			"integrity": "sha512-W5VQKZ7fdJ1X3Tko+h87YZaqRMGN1KvQKXyCM8xFdxzMIf1KCZgN4uLz3osLB1zsFcVS4ZswHY64LI26/9ACag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.0",
+				"@commitlint/types": "^20.4.3",
 				"semver": "^7.6.0"
 			},
 			"engines": {
@@ -172,33 +172,33 @@
 			}
 		},
 		"node_modules/@commitlint/lint": {
-			"version": "20.4.2",
-			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.2.tgz",
-			"integrity": "sha512-buquzNRtFng6xjXvBU1abY/WPEEjCgUipNQrNmIWe8QuJ6LWLtei/LDBAzEe5ASm45+Q9L2Xi3/GVvlj50GAug==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.3.tgz",
+			"integrity": "sha512-CYOXL23e+nRKij81+d0+dymtIi7Owl9QzvblJYbEfInON/4MaETNSLFDI74LDu+YJ0ML5HZyw9Vhp9QpckwQ0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/is-ignored": "^20.4.1",
-				"@commitlint/parse": "^20.4.1",
-				"@commitlint/rules": "^20.4.2",
-				"@commitlint/types": "^20.4.0"
+				"@commitlint/is-ignored": "^20.4.3",
+				"@commitlint/parse": "^20.4.3",
+				"@commitlint/rules": "^20.4.3",
+				"@commitlint/types": "^20.4.3"
 			},
 			"engines": {
 				"node": ">=v18"
 			}
 		},
 		"node_modules/@commitlint/load": {
-			"version": "20.4.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.0.tgz",
-			"integrity": "sha512-Dauup/GfjwffBXRJUdlX/YRKfSVXsXZLnINXKz0VZkXdKDcaEILAi9oflHGbfydonJnJAbXEbF3nXPm9rm3G6A==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.3.tgz",
+			"integrity": "sha512-3cdJOUVP+VcgHa7bhJoWS+Z8mBNXB5aLWMBu7Q7uX8PSeWDzdbrBlR33J1MGGf7r1PZDp+mPPiFktk031PgdRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/config-validator": "^20.4.0",
+				"@commitlint/config-validator": "^20.4.3",
 				"@commitlint/execute-rule": "^20.0.0",
-				"@commitlint/resolve-extends": "^20.4.0",
-				"@commitlint/types": "^20.4.0",
-				"cosmiconfig": "^9.0.0",
+				"@commitlint/resolve-extends": "^20.4.3",
+				"@commitlint/types": "^20.4.3",
+				"cosmiconfig": "^9.0.1",
 				"cosmiconfig-typescript-loader": "^6.1.0",
 				"is-plain-obj": "^4.1.0",
 				"lodash.mergewith": "^4.6.2",
@@ -209,9 +209,9 @@
 			}
 		},
 		"node_modules/@commitlint/message": {
-			"version": "20.4.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.0.tgz",
-			"integrity": "sha512-B5lGtvHgiLAIsK5nLINzVW0bN5hXv+EW35sKhYHE8F7V9Uz1fR4tx3wt7mobA5UNhZKUNgB/+ldVMQE6IHZRyA==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.3.tgz",
+			"integrity": "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -219,29 +219,29 @@
 			}
 		},
 		"node_modules/@commitlint/parse": {
-			"version": "20.4.1",
-			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.1.tgz",
-			"integrity": "sha512-XNtZjeRcFuAfUnhYrCY02+mpxwY4OmnvD3ETbVPs25xJFFz1nRo/25nHj+5eM+zTeRFvWFwD4GXWU2JEtoK1/w==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.3.tgz",
+			"integrity": "sha512-hzC3JCo3zs3VkQ833KnGVuWjWIzR72BWZWjQM7tY/7dfKreKAm7fEsy71tIFCRtxf2RtMP2d3RLF1U9yhFSccA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^20.4.0",
-				"conventional-changelog-angular": "^8.1.0",
-				"conventional-commits-parser": "^6.2.1"
+				"@commitlint/types": "^20.4.3",
+				"conventional-changelog-angular": "^8.2.0",
+				"conventional-commits-parser": "^6.3.0"
 			},
 			"engines": {
 				"node": ">=v18"
 			}
 		},
 		"node_modules/@commitlint/read": {
-			"version": "20.4.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.0.tgz",
-			"integrity": "sha512-QfpFn6/I240ySEGv7YWqho4vxqtPpx40FS7kZZDjUJ+eHxu3azfhy7fFb5XzfTqVNp1hNoI3tEmiEPbDB44+cg==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.3.tgz",
+			"integrity": "sha512-j42OWv3L31WfnP8WquVjHZRt03w50Y/gEE8FAyih7GQTrIv2+pZ6VZ6pWLD/ml/3PO+RV2SPtRtTp/MvlTb8rQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/top-level": "^20.4.0",
-				"@commitlint/types": "^20.4.0",
+				"@commitlint/top-level": "^20.4.3",
+				"@commitlint/types": "^20.4.3",
 				"git-raw-commits": "^4.0.0",
 				"minimist": "^1.2.8",
 				"tinyexec": "^1.0.0"
@@ -251,14 +251,14 @@
 			}
 		},
 		"node_modules/@commitlint/resolve-extends": {
-			"version": "20.4.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.0.tgz",
-			"integrity": "sha512-ay1KM8q0t+/OnlpqXJ+7gEFQNlUtSU5Gxr8GEwnVf2TPN3+ywc5DzL3JCxmpucqxfHBTFwfRMXxPRRnR5Ki20g==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.3.tgz",
+			"integrity": "sha512-QucxcOy+00FhS9s4Uy0OyS5HeUV+hbC6OLqkTSIm6fwMdKva+OEavaCDuLtgd9akZZlsUo//XzSmPP3sLKBPog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/config-validator": "^20.4.0",
-				"@commitlint/types": "^20.4.0",
+				"@commitlint/config-validator": "^20.4.3",
+				"@commitlint/types": "^20.4.3",
 				"global-directory": "^4.0.1",
 				"import-meta-resolve": "^4.0.0",
 				"lodash.mergewith": "^4.6.2",
@@ -269,16 +269,16 @@
 			}
 		},
 		"node_modules/@commitlint/rules": {
-			"version": "20.4.2",
-			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.2.tgz",
-			"integrity": "sha512-oz83pnp5Yq6uwwTAabuVQPNlPfeD2Y5ZjMb7Wx8FSUlu4sLYJjbBWt8031Z0osCFPfHzAwSYrjnfDFKtuSMdKg==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.3.tgz",
+			"integrity": "sha512-Yuosd7Grn5qiT7FovngXLyRXTMUbj9PYiSkvUgWK1B5a7+ZvrbWDS7epeUapYNYatCy/KTpPFPbgLUdE+MUrBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/ensure": "^20.4.1",
-				"@commitlint/message": "^20.4.0",
+				"@commitlint/ensure": "^20.4.3",
+				"@commitlint/message": "^20.4.3",
 				"@commitlint/to-lines": "^20.0.0",
-				"@commitlint/types": "^20.4.0"
+				"@commitlint/types": "^20.4.3"
 			},
 			"engines": {
 				"node": ">=v18"
@@ -295,9 +295,9 @@
 			}
 		},
 		"node_modules/@commitlint/top-level": {
-			"version": "20.4.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.0.tgz",
-			"integrity": "sha512-NDzq8Q6jmFaIIBC/GG6n1OQEaHdmaAAYdrZRlMgW6glYWGZ+IeuXmiymDvQNXPc82mVxq2KiE3RVpcs+1OeDeA==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.3.tgz",
+			"integrity": "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -308,13 +308,13 @@
 			}
 		},
 		"node_modules/@commitlint/types": {
-			"version": "20.4.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.0.tgz",
-			"integrity": "sha512-aO5l99BQJ0X34ft8b0h7QFkQlqxC6e7ZPVmBKz13xM9O8obDaM1Cld4sQlJDXXU/VFuUzQ30mVtHjVz74TuStw==",
+			"version": "20.4.3",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.3.tgz",
+			"integrity": "sha512-51OWa1Gi6ODOasPmfJPq6js4pZoomima4XLZZCrkldaH2V5Nb3bVhNXPeT6XV0gubbainSpTw4zi68NqAeCNCg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"conventional-commits-parser": "^6.2.1",
+				"conventional-commits-parser": "^6.3.0",
 				"picocolors": "^1.1.1"
 			},
 			"engines": {
@@ -501,84 +501,10 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
 		"node_modules/@napi-rs/canvas": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.94.tgz",
-			"integrity": "sha512-8jBkvqynXNdQPNZjLJxB/Rp9PdnnMSHFBLzPmMc615nlt/O6w0ergBbkEDEOr8EbjL8nRQDpEklPx4pzD7zrbg==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.96.tgz",
+			"integrity": "sha512-6NNmNxvoJKeucVjxaaRUt3La2i5jShgiAbaY3G/72s1Vp3U06XPrAIxkAjBxpDcamEn/t+WJ4OOlGmvILo4/Ew==",
 			"license": "MIT",
 			"workspaces": [
 				"e2e/*"
@@ -591,23 +517,23 @@
 				"url": "https://github.com/sponsors/Brooooooklyn"
 			},
 			"optionalDependencies": {
-				"@napi-rs/canvas-android-arm64": "0.1.94",
-				"@napi-rs/canvas-darwin-arm64": "0.1.94",
-				"@napi-rs/canvas-darwin-x64": "0.1.94",
-				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.94",
-				"@napi-rs/canvas-linux-arm64-gnu": "0.1.94",
-				"@napi-rs/canvas-linux-arm64-musl": "0.1.94",
-				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.94",
-				"@napi-rs/canvas-linux-x64-gnu": "0.1.94",
-				"@napi-rs/canvas-linux-x64-musl": "0.1.94",
-				"@napi-rs/canvas-win32-arm64-msvc": "0.1.94",
-				"@napi-rs/canvas-win32-x64-msvc": "0.1.94"
+				"@napi-rs/canvas-android-arm64": "0.1.96",
+				"@napi-rs/canvas-darwin-arm64": "0.1.96",
+				"@napi-rs/canvas-darwin-x64": "0.1.96",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.96",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.96",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.96",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.96",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.96",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.96",
+				"@napi-rs/canvas-win32-arm64-msvc": "0.1.96",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.96"
 			}
 		},
 		"node_modules/@napi-rs/canvas-android-arm64": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.94.tgz",
-			"integrity": "sha512-YQ6K83RWNMQOtgpk1aIML97QTE3zxPmVCHTi5eA8Nss4+B9JZi5J7LHQr7B5oD7VwSfWd++xsPdUiJ1+frqsMg==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.96.tgz",
+			"integrity": "sha512-ew1sPrN3dGdZ3L4FoohPfnjq0f9/Jk7o+wP7HkQZokcXgIUD6FIyICEWGhMYzv53j63wUcPvZeAwgewX58/egg==",
 			"cpu": [
 				"arm64"
 			],
@@ -625,9 +551,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-darwin-arm64": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.94.tgz",
-			"integrity": "sha512-h1yl9XjqSrYZAbBUHCVLAhwd2knM8D8xt081Pv40KqNJXfeMmBrhG1SfroRymG2ak+pl42iQlWjFZ2Z8AWFdSw==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.96.tgz",
+			"integrity": "sha512-Q/wOXZ5PzTqpdmA5eUOcegCf4Go/zz3aZ5DlzSeDpOjFmfwMKh8EzLAoweQ+mJVagcHQyzoJhaTEnrO68TNyNg==",
 			"cpu": [
 				"arm64"
 			],
@@ -645,9 +571,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-darwin-x64": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.94.tgz",
-			"integrity": "sha512-rkr/lrafbU0IIHebst+sQJf1HjdHvTMN0GGqWvw5OfaVS0K/sVxhNHtxi8oCfaRSvRE62aJZjWTcdc2ue/o6yw==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.96.tgz",
+			"integrity": "sha512-UrXiQz28tQEvGM1qvyptewOAfmUrrd5+wvi6Rzjj2VprZI8iZ2KIvBD2lTTG1bVF95AbeDeG7PJA0D9sLKaOFA==",
 			"cpu": [
 				"x64"
 			],
@@ -665,9 +591,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.94.tgz",
-			"integrity": "sha512-q95TDo32YkTKdi+Sp2yQ2Npm7pmfKEruNoJ3RUIw1KvQQ9EHKL3fii/iuU60tnzP0W+c8BKN7BFstNFcm2KXCQ==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.96.tgz",
+			"integrity": "sha512-I90ODxweD8aEP6XKU/NU+biso95MwCtQ2F46dUvhec1HesFi0tq/tAJkYic/1aBSiO/1kGKmSeD1B0duOHhEHQ==",
 			"cpu": [
 				"arm"
 			],
@@ -685,11 +611,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.94.tgz",
-			"integrity": "sha512-Je5/gKVybWAoIGyDOcJF1zYgBTKWkPIkfOgvCzrQcl8h7DiDvRvEY70EapA+NicGe4X3DW9VsCT34KZJnerShA==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.96.tgz",
+			"integrity": "sha512-Dx/0+RFV++w3PcRy+4xNXkghhXjA5d0Mw1bs95emn5Llinp1vihMaA6WJt3oYv2LAHc36+gnrhIBsPhUyI2SGw==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -705,11 +634,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.94.tgz",
-			"integrity": "sha512-9YleDDauDEZNsFnfz3HyZvp1LK1ECu8N2gDUg1wtL7uWLQv8dUbfVeFtp5HOdxht1o7LsWRmQeqeIbnD4EqE2A==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.96.tgz",
+			"integrity": "sha512-UvOi7fii3IE2KDfEfhh8m+LpzSRvhGK7o1eho99M2M0HTik11k3GX+2qgVx9EtujN3/bhFFS1kSO3+vPMaJ0Mg==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -725,11 +657,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.94.tgz",
-			"integrity": "sha512-lQUy9Xvz7ch8+0AXq8RkioLD41iQ6EqdKFu5uV40BxkBDijB2SCm1jna/BRhqitQRSjwAk2KlLUxTjHChyfNGg==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.96.tgz",
+			"integrity": "sha512-MBSukhGCQ5nRtf9NbFYWOU080yqkZU1PbuH4o1ROvB4CbPl12fchDR35tU83Wz8gWIM9JTn99lBn9DenPIv7Ig==",
 			"cpu": [
 				"riscv64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -745,11 +680,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.94.tgz",
-			"integrity": "sha512-0IYgyuUaugHdWxXRhDQUCMxTou8kAHHmpIBFtbmdRlciPlfK7AYQW5agvUU1PghPc5Ja3Zzp5qZfiiLu36vIWQ==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.96.tgz",
+			"integrity": "sha512-I/ccu2SstyKiV3HIeVzyBIWfrJo8cN7+MSQZPnabewWV6hfJ2nY7Df2WqOHmobBRUw84uGR6zfQHsUEio/m5Vg==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -765,11 +703,14 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-x64-musl": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.94.tgz",
-			"integrity": "sha512-xuetfzzcflCIiBw2HJlOU4/+zTqhdxoe1BEcwdBsHAd/5wAQ4Pp+FGPi5g74gDvtcXQmTdEU3fLQvHc/j3wbxQ==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.96.tgz",
+			"integrity": "sha512-H3uov7qnTl73GDT4h52lAqpJPsl1tIUyNPWJyhQ6gHakohNqqRq3uf80+NEpzcytKGEOENP1wX3yGwZxhjiWEQ==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -785,9 +726,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.94.tgz",
-			"integrity": "sha512-2F3p8wci4Q4vjbENlQtSibqFWxBdpzYk1c8Jh1mqqLE92rBKElG018dBJ6C8Dp49vE350Hmy5LrfdLgFKMG8sg==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.96.tgz",
+			"integrity": "sha512-ATp6Y+djOjYtkfV/VRH7CZ8I1MEtkUQBmKUbuWw5zWEHHqfL0cEcInE4Cxgx7zkNAhEdBbnH8HMVrqNp+/gwxA==",
 			"cpu": [
 				"arm64"
 			],
@@ -805,9 +746,9 @@
 			}
 		},
 		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
-			"version": "0.1.94",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.94.tgz",
-			"integrity": "sha512-hjwaIKMrQLoNiu3724octSGhDVKkBwJtMeQ3qUXOi+y60h2q6Sxq3+MM2za3V88+XQzzwn0DgG0Xo6v6gzV8kQ==",
+			"version": "0.1.96",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.96.tgz",
+			"integrity": "sha512-UYGdTltVd+Z8mcIuoqGmAXXUvwH5CLf2M6mIB5B0/JmX5J041jETjqtSYl7gN+aj3k1by/SG6sS0hAwCqyK7zw==",
 			"cpu": [
 				"x64"
 			],
@@ -822,17 +763,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Brooooooklyn"
-			}
-		},
-		"node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@pkgr/core": {
@@ -859,6 +789,19 @@
 			},
 			"peerDependencies": {
 				"prettier": "^3.0.0"
+			}
+		},
+		"node_modules/@simple-libs/stream-utils": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+			"integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/dangreen"
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin": {
@@ -921,9 +864,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-			"integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+			"version": "25.3.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.4.tgz",
+			"integrity": "sha512-NB1qVMIPsjfYtrY+9cCTj2VqLBh/TIDmsZXtmM2Xsn+W2yMlkA9Q1Okpr9W3f1fyGgvelw8ojumDsv8Vc0xufQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1261,16 +1204,13 @@
 			}
 		},
 		"node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1323,9 +1263,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1398,36 +1338,6 @@
 				"assertion-error": "^1.0.1"
 			}
 		},
-		"node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/chalk/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
@@ -1472,16 +1382,16 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"readdirp": "^4.0.1"
+				"readdirp": "^5.0.0"
 			},
 			"engines": {
-				"node": ">= 14.16.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
@@ -1504,14 +1414,14 @@
 			}
 		},
 		"node_modules/cli-truncate": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-			"integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+			"integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"slice-ansi": "^7.1.0",
-				"string-width": "^8.0.0"
+				"slice-ansi": "^8.0.0",
+				"string-width": "^8.2.0"
 			},
 			"engines": {
 				"node": ">=20"
@@ -1543,6 +1453,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/cliui/node_modules/is-fullwidth-code-point": {
@@ -1650,9 +1576,9 @@
 			}
 		},
 		"node_modules/conventional-changelog-angular": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz",
-			"integrity": "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
+			"integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1663,9 +1589,9 @@
 			}
 		},
 		"node_modules/conventional-changelog-conventionalcommits": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.1.0.tgz",
-			"integrity": "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.0.tgz",
+			"integrity": "sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1676,12 +1602,13 @@
 			}
 		},
 		"node_modules/conventional-commits-parser": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
-			"integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
+			"integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@simple-libs/stream-utils": "^1.2.0",
 				"meow": "^13.0.0"
 			},
 			"bin": {
@@ -1692,9 +1619,9 @@
 			}
 		},
 		"node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1824,13 +1751,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1895,9 +1815,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.1.tgz",
-			"integrity": "sha512-20MV9SUdeN6Jd84xESsKhRly+/vxI+hwvpBMA93s+9dAcjdCuCojn4IqUGS3lvVaqjVYGYHSRMCpeFtF2rQYxQ==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
+			"integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1911,7 +1831,7 @@
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
@@ -2303,28 +2223,11 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+			"integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/foreground-child": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
@@ -2353,6 +2256,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
 			"integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
+			"deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2381,22 +2285,18 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+			"engines": {
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -2432,9 +2332,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "17.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
-			"integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
+			"version": "17.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+			"integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2729,22 +2629,6 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
 		},
-		"node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
 		"node_modules/jiti": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2835,19 +2719,18 @@
 			"license": "MIT"
 		},
 		"node_modules/lint-staged": {
-			"version": "16.2.7",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
-			"integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.2.tgz",
+			"integrity": "sha512-xKqhC2AeXLwiAHXguxBjuChoTTWFC6Pees0SHPwOpwlvI3BH7ZADFPddAdN3pgo3aiKgPUx/bxE78JfUnxQnlg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"commander": "^14.0.2",
+				"commander": "^14.0.3",
 				"listr2": "^9.0.5",
 				"micromatch": "^4.0.8",
-				"nano-spawn": "^2.0.0",
-				"pidtree": "^0.6.0",
 				"string-argv": "^0.3.2",
-				"yaml": "^2.8.1"
+				"tinyexec": "^1.0.2",
+				"yaml": "^2.8.2"
 			},
 			"bin": {
 				"lint-staged": "bin/lint-staged.js"
@@ -2935,23 +2818,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/log-symbols": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/log-update": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -2972,12 +2838,32 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+		"node_modules/log-update/node_modules/slice-ansi": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+			"integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
 			"dev": true,
-			"license": "ISC"
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"is-fullwidth-code-point": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "11.2.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/mdast-util-from-markdown": {
 			"version": "0.8.5",
@@ -3083,9 +2969,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-			"integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -3119,28 +3005,28 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "11.7.5",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-			"integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+			"version": "12.0.0-beta-10",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-12.0.0-beta-10.tgz",
+			"integrity": "sha512-edlHS69tgkDTSQotUVP6KNtrIV/qQB/uwbxLHE8yFoD2htrbtFv21CyyNVUC9LvcHNeMwNeR2uxJYxYhWPKGTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browser-stdout": "^1.3.1",
-				"chokidar": "^4.0.1",
+				"chokidar": "^5.0.0",
 				"debug": "^4.3.5",
-				"diff": "^7.0.0",
+				"diff": "^8.0.3",
 				"escape-string-regexp": "^4.0.0",
 				"find-up": "^5.0.0",
-				"glob": "^10.4.5",
+				"glob": "^13.0.0",
 				"he": "^1.2.0",
 				"is-path-inside": "^3.0.3",
+				"is-unicode-supported": "^0.1.0",
 				"js-yaml": "^4.1.0",
-				"log-symbols": "^4.1.0",
-				"minimatch": "^9.0.5",
+				"minimatch": "^10.2.2",
 				"ms": "^2.1.3",
 				"picocolors": "^1.1.1",
-				"serialize-javascript": "^6.0.2",
-				"strip-json-comments": "^3.1.1",
+				"serialize-javascript": "^7.0.2",
+				"strip-json-comments": "^5.0.3",
 				"supports-color": "^8.1.1",
 				"workerpool": "^9.2.0",
 				"yargs": "^17.7.2",
@@ -3152,7 +3038,7 @@
 				"mocha": "bin/mocha.js"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/ms": {
@@ -3160,19 +3046,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
-		},
-		"node_modules/nano-spawn": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-			"integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.17"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -3254,13 +3127,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/package-json-from-dist": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0"
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3332,32 +3198,32 @@
 			}
 		},
 		"node_modules/path-scurry": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.18"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/pdfjs-dist": {
-			"version": "5.4.624",
-			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.624.tgz",
-			"integrity": "sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==",
+			"version": "5.5.207",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.5.207.tgz",
+			"integrity": "sha512-WMqqw06w1vUt9ZfT0gOFhMf3wHsWhaCrxGrckGs5Cci6ybDW87IvPaOd2pnBwT6BJuP/CzXDZxjFgmSULLdsdw==",
 			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=20.16.0 || >=22.3.0"
+				"node": ">=20.19.0 || >=22.13.0 || >=24"
 			},
 			"optionalDependencies": {
-				"@napi-rs/canvas": "^0.1.88",
+				"@napi-rs/canvas": "^0.1.95",
 				"node-readable-to-web-readable-stream": "^0.4.2"
 			}
 		},
@@ -3379,19 +3245,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pidtree": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-			"integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"pidtree": "bin/pidtree.js"
-			},
-			"engines": {
-				"node": ">=0.10"
 			}
 		},
 		"node_modules/pixelmatch": {
@@ -3464,24 +3317,14 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/readdirp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 14.18.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"type": "individual",
@@ -3549,27 +3392,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3584,13 +3406,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+			"integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -3628,33 +3450,20 @@
 			}
 		},
 		"node_modules/slice-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-			"integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+			"integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"is-fullwidth-code-point": "^5.0.0"
+				"ansi-styles": "^6.2.3",
+				"is-fullwidth-code-point": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"node_modules/slice-ansi/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/split2": {
@@ -3694,63 +3503,14 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -3759,38 +3519,14 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
-		"node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+			"integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -4012,86 +3748,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/wrap-ansi/node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"genTypes": "tsc",
 		"lint": "eslint . --fix",
 		"pretty": "npx prettier --write .",
-		"test": "mocha --recursive --timeout 20000",
+		"test": "mocha --recursive --timeout 25000",
 		"pre-commit": "npx lint-staged",
 		"prepare": "node .husky/install.mjs"
 	},
@@ -24,37 +24,33 @@
 	"homepage": "https://github.com/marcdacz/compare-pdf#readme",
 	"keywords": ["pdf", "graphicsMagick", "imageMagick", "compare pdf", "test pdf"],
 	"devDependencies": {
-		"@commitlint/cli": "^20.4.2",
-		"@commitlint/config-conventional": "^20.4.2",
-		"@commitlint/format": "^20.4.0",
+		"@commitlint/cli": "^20.4.3",
+		"@commitlint/config-conventional": "^20.4.3",
+		"@commitlint/format": "^20.4.3",
 		"@eslint/js": "^10.0.1",
 		"@prettier/plugin-xml": "^3.4.2",
 		"@stylistic/eslint-plugin": "^5.9.0",
 		"@types/mocha": "^10.0.10",
 		"chai": "^6.2.2",
 		"chai-files": "^1.4.0",
-		"eslint": "^10.0.1",
+		"eslint": "^10.0.2",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-markdown": "^5.1.0",
 		"eslint-plugin-prettier": "^5.5.5",
-		"globals": "^17.3.0",
+		"globals": "^17.4.0",
 		"husky": "^9.1.7",
-		"lint-staged": "^16.2.7",
-		"mocha": "^11.7.5",
+		"lint-staged": "^16.3.2",
+		"mocha": "12.0.0-beta-10",
 		"prettier": "^3.8.1",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.56.1"
 	},
 	"dependencies": {
-		"@napi-rs/canvas": "^0.1.94",
+		"@napi-rs/canvas": "^0.1.96",
 		"gm": "^1.25.1",
-		"pdfjs-dist": "^5.4.624",
+		"pdfjs-dist": "^5.5.207",
 		"pixelmatch": "^7.1.0",
 		"pngjs": "^7.0.0"
-	},
-	"overrides": {
-		"diff": "8.0.3",
-		"minimatch": "10.2.2"
 	},
 	"lint-staged": {
 		"**/*": ["eslint --cache --fix", "prettier --write --ignore-unknown"]


### PR DESCRIPTION
Bumped the following dependencies:
 @commitlint/cli                   ^20.4.2  →   ^20.4.3
 @commitlint/config-conventional   ^20.4.2  →   ^20.4.3
 @commitlint/format                ^20.4.0  →   ^20.4.3
 @napi-rs/canvas                   ^0.1.94  →   ^0.1.96
 eslint                            ^10.0.1  →   ^10.0.2
 globals                           ^17.3.0  →   ^17.4.0
 lint-staged                       ^16.2.7  →   ^16.3.2
 pdfjs-dist                       ^5.4.624  →  ^5.5.207
 mocha                             ^11.7.5  → 12.0.0-beta-10